### PR TITLE
Remove sudo prefix from commands

### DIFF
--- a/src/pishutdown.c
+++ b/src/pishutdown.c
@@ -28,9 +28,9 @@ static void get_string (char *cmd, char *name)
 
 void button_handler (GtkWidget *widget, gpointer data)
 {
-    if (!strcmp (data, "shutdown")) system ("sudo shutdown -h now");
-    if (!strcmp (data, "reboot")) system ("sudo reboot");
-    if (!strcmp (data, "exit")) system ("sudo pkill lxsession");
+    if (!strcmp (data, "shutdown")) system ("shutdown -h now");
+    if (!strcmp (data, "reboot")) system ("reboot");
+    if (!strcmp (data, "exit")) system ("pkill lxsession");
 }
 
 gint delete_event (GtkWidget *widget, GdkEvent *event, gpointer data)


### PR DESCRIPTION
Removed the "sudo" prefix from the Shutdown/Reboot/Logout commands as they only work if the user is set NOPASSWD in sudoers (as the default "Pi" user is) and is, in any case, unnecessary.

Previously if you create a user without NOPASSWD, they cannot log out.

FYI: This is my first Github pull request so if I accidentally... the entire internet... well, that's why! :D
