### PR TITLE
[feature request] Add check for escape key press

### DIFF
--- a/src/pishutdown.c
+++ b/src/pishutdown.c
@@ -8,6 +8,7 @@
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
 #include <gtk/gtk.h>
+#include <gdk/gdkkeysyms.h>
 #include <gdk/gdkx.h>
 
 #define MIN_WIDTH 275
@@ -39,6 +40,15 @@ gint delete_event (GtkWidget *widget, GdkEvent *event, gpointer data)
     return FALSE;
 }
 
+static gboolean check_escape (GtkWidget *widget, GdkEventKey *event, gpointer data)
+{
+    if (event->keyval == GDK_KEY_Escape) {
+        gtk_main_quit ();
+        return TRUE;
+    }
+    return FALSE;
+}
+
 /* The dialog... */
 
 int main (int argc, char *argv[])
@@ -65,6 +75,7 @@ int main (int argc, char *argv[])
     gtk_window_set_icon (GTK_WINDOW (dlg), gdk_pixbuf_new_from_file ("/usr/share/raspberrypi-artwork/raspitr.png", NULL));
     gtk_window_set_resizable (GTK_WINDOW (dlg), FALSE);
     gtk_signal_connect (GTK_OBJECT (dlg), "delete_event", G_CALLBACK (delete_event), NULL);
+    gtk_signal_connect (GTK_OBJECT (dlg), "key_press_event", G_CALLBACK(check_escape), NULL);
 
     box = gtk_table_new (3, 1, TRUE);
     gtk_table_set_row_spacings (GTK_TABLE (box), 5);


### PR DESCRIPTION
This might be subjective, but the shutdown window "feels" like a dialogue to me and so it would be nice to be able to close it by pressing the escape key.