### PR TITLE
Don't send wall message before shutdown/reboot

### DIFF
--- a/src/pishutdown.c
+++ b/src/pishutdown.c
@@ -50,8 +50,8 @@ GDBusProxy *proxy;
 
 static void button_handler (GtkWidget *widget, gpointer data)
 {
-    if (!strcmp (data, "shutdown")) system ("/usr/bin/pkill orca;/sbin/shutdown -h now");
-    if (!strcmp (data, "reboot")) system ("/usr/bin/pkill orca;/sbin/reboot");
+    if (!strcmp (data, "shutdown")) system ("/usr/bin/pkill orca;/sbin/shutdown -h now --no-wall");
+    if (!strcmp (data, "reboot")) system ("/usr/bin/pkill orca;/sbin/reboot --no-wall");
     if (!strcmp (data, "exit"))
     {
         system ("/usr/bin/pkill orca");


### PR DESCRIPTION
At the moment clicking on the Shutdown or Reboot button flashes up a `wall` message on screen along the lines of:

> The system is going down for reboot NOW!

This PR adds the `--no-wall` option to both `shutdown` and `reboot` for a clean shutdown/reboot (I don't believe it's necessary or desirable to broadcast terminal wall messages when using a GUI to shutdown or reboot the system).